### PR TITLE
Ensure proper permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ tests:
 	$(DC) -unittest $(LIB_FLAGS) $(FLAGS) $(TEST_SOURCES) -of$(TEST_PROGRAM)
 
 check: tests
+	chmod 555 $(LIBCURL)
 	cp $(LIBCURL) .
 	./$(TEST_PROGRAM)
 


### PR DESCRIPTION
Ran into an issue whereby libcurl.dll had no xwr permissions for anybody
which in turn prevented the dll from loading into unittests and presented
what would be an otherwise obscure failure for anyone unfamiliar with this
symptom.

Added a chmod line as this should do no harm but kill the potential for this
strange error. Sudo was not necessary on my system.
