### PR TITLE
Fix the missing endpoint in connection arguments

### DIFF
--- a/driver/driver.d
+++ b/driver/driver.d
@@ -84,7 +84,7 @@ export SQLRETURN SQLDriverConnectW(
         }
 
         if (driverCompletion != DriverCompletion.NOPROMPT) {
-            connectionArguments ~= ";server=;port=;prestoCatalog=;prestoSchema=;";
+            connectionArguments ~= ";endpoint=;prestoCatalog=;prestoSchema=;";
             connectionArguments = wtext(getTextInput(text(connectionArguments)));
         }
 


### PR DESCRIPTION
Endpoint is missing in the connection arguments in the popped up text file so the driver fails with "object.Exception@driver\driver.d(94): dllEnforce failed" as endpoint is required.
