### PR TITLE
Catalog can't be empty

### DIFF
--- a/driver/util.d
+++ b/driver/util.d
@@ -485,7 +485,7 @@ StatementClient runQuery(OdbcStatement statementHandle, string query) {
     with (statementHandle.connection) {
         auto session = ClientSession(endpoint, "ODBC Driver");
         session.catalog = catalog;
-        session.schema = schema.empty ? "tiny" : schema;
+        session.schema = schema;
 
         return StatementClient(session, query);
     }


### PR DESCRIPTION
If the user leaves the catalog information empty, driver gets HTTP 400 on subsequent operations as Presto doesn't allow that (see https://github.com/facebook/presto/blob/e9a9eeb50e0511d90295ad9459fed802af355666/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java#L157)

This change also puts the initialization of the defaults in driver.d:parseConnectionString
