### PR TITLE
Compile on OSX

### DIFF
--- a/driver/driver.d
+++ b/driver/driver.d
@@ -40,9 +40,8 @@ import presto.odbcdriver.typeinfo;
 
 //////  DLL entry point for global initializations/finalizations if any
 
-version(unittest) {} else {
-    extern(Windows) BOOL DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
-    {
+version (Windows) {
+    extern(Windows) BOOL DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
         if (fdwReason == DLL_PROCESS_ATTACH) { // DLL is being loaded
             Runtime.initialize();
             import core.memory;
@@ -53,6 +52,18 @@ version(unittest) {} else {
         }
 
         return TRUE;
+    }
+} else {
+    shared static this() {
+        Runtime.initialize();
+        import core.memory;
+        GC.disable();
+        assert(false, "Debugging an issue whereby this function is not called");
+        logMessage("Presto ODBC Driver loaded by application or driver manager");
+    }
+
+    shared static ~this() {
+        Runtime.terminate();
     }
 }
 

--- a/driver/util.d
+++ b/driver/util.d
@@ -33,7 +33,11 @@ import presto.client.statementclient : StatementClient, ClientSession;
 
 import presto.odbcdriver.handles : OdbcStatement, OdbcConnection;
 
-enum tempPath = "C:\\temp\\";
+version (Windows) {
+    enum tempPath = "C:\\temp\\";
+} else {
+    enum tempPath = "/tmp/";
+}
 auto logBuffer = appender!wstring;
 
 void logMessage(string file = __FILE__, int line = __LINE__, TList...)(auto ref TList vs) {
@@ -72,9 +76,11 @@ void flushLogBuffer() {
 }
 
 void showPopupMessage(TList...)(auto ref TList vs) {
-    import std.c.windows.windows;
-    auto message = buildDebugMessage(vs) ~ '\0';
-    MessageBoxW(GetForegroundWindow(), message.ptr, "Presto ODBC Driver", MB_OK);
+    version (Windows) {
+        import std.c.windows.windows;
+        auto message = buildDebugMessage(vs) ~ '\0';
+        MessageBoxW(GetForegroundWindow(), message.ptr, "Presto ODBC Driver", MB_OK);
+    }
 }
 
 unittest {
@@ -342,11 +348,11 @@ private auto emplaceWrapper(T, TList...)(void* memory, auto ref TList args) {
     }
 }
 
-ulong getInstanceSize(T)() if(is(T == class)) {
+size_t getInstanceSize(T)() if (is(T == class)) {
     return __traits(classInstanceSize, T);
 }
 
-ulong getInstanceSize(T)() if(!is(T == class)) {
+size_t getInstanceSize(T)() if (!is(T == class)) {
     return T.sizeof;
 }
 
@@ -360,7 +366,7 @@ unittest {
 }
 
 size_t strlen(C)(const(C)* str) {
-    ulong length = 0;
+    size_t length = 0;
     for (; str[length] != 0; ++length) {
         //Intentionally blank
     }

--- a/odbc/sqltypes.d
+++ b/odbc/sqltypes.d
@@ -42,8 +42,11 @@ version(Windows) {
     alias CHAR = char;
     alias WORD = ushort;
     alias DWORD = uint;
-    alias LPSTR = char*;
-    alias LPCSTR = const(char)*;
+    alias LPVOID = void*;
+    alias LPSTR = SQLCHAR*;
+    alias LPWSTR = SQLWCHAR*;
+    alias LPCSTR = const(SQLCHAR)*;
+    alias LPCWSTR = const(SQLWCHAR)*;
     alias LPTSTR = TCHAR*;
     alias LPDWORD = DWORD*;
     alias BOOL = int;
@@ -103,7 +106,7 @@ alias SQLHDESC = SQLHANDLE;
 version(Win32) {
     alias SQLHWND = HWND;
 } else version(OSX) {
-    alias HWND = WindowPtr;
+    alias HWND = SQLPOINTER; //WindowPtr;
     alias SQLHWND = HWND;
 } else {
     alias SQLHWND = SQLPOINTER;
@@ -225,12 +228,10 @@ struct SQLGUID {
 }
 
 alias SQLWCHAR = wchar;
-version (Windows) {} else {
-    static assert(false, "Investigate what wchar should be");
-}
 
 version(UNICODE) {
-    alias SQLTCHAR = SQLWCHAR;
+    alias TCHAR = SQLWCHAR;
 } else {
-    alias SQLTCHAR = SQLCHAR;
+    alias TCHAR = SQLCHAR;
 }
+alias SQLTCHAR = TCHAR;


### PR DESCRIPTION
This is a _first_ step. This does _not_ complete the port to OSX.
The changes in this pull request simply make the driver compile, it
does not make it run properly. There are a few more details to work out:
1. The shared static this OSX equivalent of DllMain is currently _not_
executed. This means the runtime is never initialized and the driver
then crashes.
2. There are a few more usages of the long integer type that must be
removed/tended to. Ideally we would find out that there's a 64-bit
iODBC driver, but otherwise we need to deal with this.
