### PR TITLE
Handle NaN results from Presto server

### DIFF
--- a/driver/driver.d
+++ b/driver/driver.d
@@ -451,8 +451,8 @@ void SQLExecuteImpl(OdbcStatement statementHandle) {
             result.columnMetadata = resultBatch.columnMetadata;
             foreach (row; resultBatch.data.array) {
                 auto dataRow = makeWithoutGC!PrestoResultRow();
-                foreach (columnData; row.array) {
-                    addToPrestoResultRow(columnData, dataRow);
+                foreach (i, columnData; row.array) {
+                    addToPrestoResultRow(columnData, dataRow, result.columnMetadata[i].type);
                 }
                 dllEnforce(dataRow.numberOfColumns() != 0, "Row has at least 1 column");
                 result.addRow(dataRow);

--- a/driver/prestoresults.d
+++ b/driver/prestoresults.d
@@ -32,12 +32,10 @@ void addToPrestoResultRow(JSONValue columnData, PrestoResultRow result, string r
             if (resultDataType == "string") {
                 result.addNextValue(Variant(columnData.str));
             } else {
-                //for some scalar functions that return double, we may get a "NaN" back
-                if (columnData.str == "NaN") { 
-                    result.addNextValue(Variant(double.nan));
-                } else {
+                if (columnData.str != "NaN") { 
                     dllEnforce(false, "A non-Nan double is not expected in the result");
-                }
+                } 
+                result.addNextValue(Variant(double.nan));
             }
             break;
         case JSON_TYPE.INTEGER:


### PR DESCRIPTION
with comments addressed (throw an exception when we see a non-NaN double in the result while we were expecting a string)
