### PR TITLE
Early termination of result set processing

### DIFF
--- a/client/statementclient.d
+++ b/client/statementclient.d
@@ -139,10 +139,14 @@ struct StatementClient {
         assert(!empty);
         auto response = get(results_.nextURI, session.connection);
         parseAndSetResults(response);
+        
+        if (results_.nextURI == "" && results_.succeeded) {
+            processedAll_ = true;
+        }          
     }
 
     bool empty() const nothrow {
-        return (results_.nextURI == "" && results_.succeeded) || queryTerminated_;
+        return processedAll_ || queryTerminated_;
     }
 
     void terminateQuery() {
@@ -163,6 +167,7 @@ private:
     }
 
     bool queryTerminated_ = false;
+    bool processedAll_ = false;
     ClientSession session_;
     string query_;
     Rebindable!(immutable(QueryResults)) results_;


### PR DESCRIPTION
With a custom SQL query that I have written in Tableau I noticed that the foreach loop in driver.d SQLExecuteImpl function, which traverses the result set of the query, terminates early and prevents the actual result to be returned to the application when the result data is received in the last batch retrieved from the server. The foreach construct calls the statement client's empty(), front(), and popfront() functions in order as expected, but the empty() function returns true before the last result (that contains the actual result of the query) is retrieved & processed with the front() call. 
