### PR TITLE
Proxy-side hostname resolution

### DIFF
--- a/client/statementclient.d
+++ b/client/statementclient.d
@@ -74,7 +74,7 @@ struct ClientSession {
             }
             http.proxy = hostPort[0];
             http.proxyPort = to!ushort(hostPort[2]);
-            http.proxyType = CurlProxy.socks5;
+            http.proxyType = CurlProxy.socks5_hostname;
         }
 
         return addHeaders(http);


### PR DESCRIPTION
Currently the driver sets the proxy type to `socks5`, which performs the hostname resolution locally. However, it is also common to let the proxy do the hostname resolution with the `socks5_hostname` proxy type. It's possible to do this by specifying the proxy type in the connection string as `proxyEndpoint=socks5h://proxy_host:port` . This PR updates the connection parameters documentation to reflect that.
