### PR TITLE
Terminate result set processing for failed queries

### DIFF
--- a/client/statementclient.d
+++ b/client/statementclient.d
@@ -140,7 +140,7 @@ struct StatementClient {
         auto response = get(results_.nextURI, session.connection);
         parseAndSetResults(response);
         
-        if ((results_.nextURI == "" && results_.succeeded) || (!results_.succeeded)) {
+        if (!results_.succeeded || results_.nextURI == "") {
             processedAll_ = true;
         }          
     }

--- a/client/statementclient.d
+++ b/client/statementclient.d
@@ -140,7 +140,7 @@ struct StatementClient {
         auto response = get(results_.nextURI, session.connection);
         parseAndSetResults(response);
         
-        if (results_.nextURI == "" && results_.succeeded) {
+        if ((results_.nextURI == "" && results_.succeeded) || (!results_.succeeded)) {
             processedAll_ = true;
         }          
     }


### PR DESCRIPTION
Tableau crashes when a custom query is run against a table that doesn't exist. The reason is that result set processing logic doesn't terminate on failed queries (query fails since the table doesn't exist)
